### PR TITLE
Table Pagination & Dropping Database Connection Fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,10 @@ This project is intended to be open source and public, so any and all contributi
 
 
 ## Release History
+* 2.2.1
+    * The data tables on the report now have pages! Instead of getting a list of 100 items, you now see five at a time.  
+    * Also fixed a server issue while I was in there. The DB provider [clearDB], has a non-adjustable server timeout configuration. To mitigate dropping connections, we now ping the server between requests. The pull request below has more details, including the link to the stackoverflow post I used.
+    * [(See pull request)](https://github.com/zshafiqu/vehicleinfo.org/pull/14)
 * 2.2.0
     * Resolves issue where the search form made it difficult to get a report on cars where the name is ambiguous, or not well defined, such as ‘BMW 3-series’ or ‘Lexus ES’. Because of this, the web report interface’s search form was swapped out for a select option.
     * Utilized the fetch() API to grab the updated lists, and they are asynchronously rendered as you change your selections.  

--- a/server.py
+++ b/server.py
@@ -178,23 +178,14 @@ def report():
     makes = get_distinct_makes_for_year(1992)
     form = Form()
 
-    # When I was testing, I'd get an error for 'lost connection to database.'
-    # Using this while loop as a method to ensure two attempts before rendering an error page
-    i = 0
-    while True:
-        if i == 2: # Attempt twice before going to the error page
-            return render_template('error.html')
-        try:
-            # Because jsonify() converts a python object to a Flask response, you need to use '.json' to make references
-            # list comprehension to create tuples with (value, label) given by resulting lists from function calls
-            form.make.choices = [(make['value'], make['label']) for make in get_distinct_makes_for_year(1992).json['makes']]
-            form.model.choices = [(model['value'], model['label']) for model in get_all_models_for_year(form.make.choices[0][0], 1992).json['models']]
-        except:
-            # Lost connection with DB server
-            i += 1
-            continue
-        break # Exit on success
-
+    try:
+        # Because jsonify() converts a python object to a Flask response, you need to use '.json' to make references
+        # list comprehension to create tuples with (value, label) given by resulting lists from function calls
+        form.make.choices = [(make['value'], make['label']) for make in get_distinct_makes_for_year(1992).json['makes']]
+        form.model.choices = [(model['value'], model['label']) for model in get_all_models_for_year(form.make.choices[0][0], 1992).json['models']]
+    except:
+        return render_template('error.html')
+    
     # If POST request, that means client hit 'submit' and is requesting a report
     if request.method == "POST":
         year = form.year.data

--- a/server.py
+++ b/server.py
@@ -185,7 +185,7 @@ def report():
         form.model.choices = [(model['value'], model['label']) for model in get_all_models_for_year(form.make.choices[0][0], 1992).json['models']]
     except:
         return render_template('error.html')
-    
+
     # If POST request, that means client hit 'submit' and is requesting a report
     if request.method == "POST":
         year = form.year.data
@@ -253,6 +253,6 @@ def about():
     return render_template('about.html')
 # ----------------------
 if __name__ == '__main__':
-    # from waitress import serve
-    # serve(app)
-    app.run(debug=True)
+    from waitress import serve
+    serve(app)
+    

--- a/server.py
+++ b/server.py
@@ -255,4 +255,3 @@ def about():
 if __name__ == '__main__':
     from waitress import serve
     serve(app)
-    

--- a/server.py
+++ b/server.py
@@ -3,6 +3,7 @@ from flask_sqlalchemy import SQLAlchemy
 from flask_talisman import Talisman
 from flask_wtf import FlaskForm
 from wtforms import SelectField
+from sqlalchemy.pool import QueuePool
 import requests, json, os, ast, datetime
 # ----------------------
 # Activate virtual env with - source env/bin/activate
@@ -23,6 +24,12 @@ app.config['SQLALCHEMY_DATABASE_URI'] = os.environ.get('BASE_URI')
 # ----------------------
 # Bind app to db obj
 db = SQLAlchemy(app)
+# ----------------------
+# Was running into a timeouterror for mySQL on Heroku's clearDB instance.
+# Referencing stackoverflow, "the only work around I could find for this by
+# talking to the ClearDB people is to add in the pessimistic ping when creating the engine."
+# Not ideal since its pings DB everytime before you do a query, but avoids 500 Internal Server Error
+db = SQLAlchemy(engine_options={"pool_size": 10, "poolclass":QueuePool, "pool_pre_ping":True})
 # ----------------------
 ''' Template filter converter for JSON formatted time '''
 @app.template_filter('strftime')

--- a/server.py
+++ b/server.py
@@ -255,5 +255,6 @@ def about():
     return render_template('about.html')
 # ----------------------
 if __name__ == '__main__':
-    from waitress import serve
-    serve(app)
+    # from waitress import serve
+    # serve(app)
+    app.run(debug=True)

--- a/templates/changelog.html
+++ b/templates/changelog.html
@@ -43,6 +43,11 @@
                   <td>2.2</td>
                   <td>There was an issue where the search form made it difficult to get a report on cars where the name is ambiguous, or not well defined, such as ‘BMW 3-series’ or ‘Lexus ES’. Because of this, the web report interface’s search form was swapped out for a select option. <br><br> I utilized the <i>fetch()</i> API to grab the updated lists, and they are asynchronously rendered as you change your selections.</td>
                 </tr>
+                <tr>
+                  <td>03-24-2020</td>
+                  <td>2.2.1</td>
+                  <td>The data tables on the report now have pages! Instead of getting a list of 100 items, you now see five at a time.<br><br> Also fixed a server issue while I was in there. The DB provider [clearDB], has a non-adjustable server timeout configuration. To mitigate dropping connections, we now ping the server between requests.<a href="https://github.com/zshafiqu/vehicleinfo.org/pull/14" target="_blank"> See pull request here.</a></td>
+                </tr>
               </tbody>
             </table>
           </div>

--- a/templates/layout.html
+++ b/templates/layout.html
@@ -66,6 +66,8 @@
     <script src="{{url_for('static', filename='js/bootstrap.min.js')}}"></script>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/baguettebox.js/1.10.0/baguetteBox.min.js"></script>
     <script src="{{url_for('static', filename='js/script.min.js')}}"></script>
+    <!-- Additional scripts that may be unique to a specific page -->
+    {% block scripts %} {% endblock %}
     <!-- SCRIPTS -->
   </body>
   <!-- End Body -->

--- a/templates/report.html
+++ b/templates/report.html
@@ -45,7 +45,7 @@
   let year_select = document.getElementById('year');
   let make_select = document.getElementById('make');
   let model_select = document.getElementById('model');
-  var delayInMilliseconds = 250;
+  var delayInMilliseconds = 500;
 
   // Update makes and models onchange() for year
   year_select.onchange = function() {

--- a/templates/view_report.html
+++ b/templates/view_report.html
@@ -7,6 +7,11 @@
     }
     /* Adjust report column on mobile view */
   }
+  .row {
+    /* have to add this because datatables adds margin */
+    margin-left:0px !important;
+    margin-right:0px !important;
+  }
 
 </style>
 <main class="page contact-us-page">
@@ -131,7 +136,7 @@
               {{data['Results'][0]['Model']}}
             </h2>
             <div class="table-responsive">
-              <table class="table">
+              <table id="table1" class="table">
                 <thead>
                   <tr>
                     <th>Recall Number</th>
@@ -169,7 +174,7 @@
               {{data['Results'][0]['Model']}}
             </h2>
             <div class="table-responsive">
-              <table class="table">
+              <table id="table2" class="table">
                 <thead>
                   <tr>
                     <th>Incident Date</th>
@@ -192,8 +197,39 @@
         </div>
       </div>
       <!-- END ROW 3 -->
-
     </div>
   </section>
 </main>
 {% endblock content %}
+
+{% block scripts %}
+<!-- Data tables scripts -->
+<script src="https://cdn.datatables.net/1.10.20/js/jquery.dataTables.min.js" type="text/javascript"></script>
+<script src="https://cdn.datatables.net/1.10.20/js/dataTables.bootstrap4.min.js" type="text/javascript"></script>
+<script src="https://cdn.datatables.net/1.10.20/js/dataTables.bootstrap4.min.js" type="text/javascript"></script>
+<script type="text/javascript">
+   $(function() {
+    $("#table1").dataTable({
+        "iDisplayLength": 5,
+        "lengthChange": false,
+        "stateSave": false,
+        "info":false,
+       });
+    $("#table2").dataTable({
+      "iDisplayLength": 5,
+      "lengthChange": false,
+      "stateSave": false,
+      "info":false,
+      });
+   });
+</script>
+<!-- Have to add this script to resize the dumb data table stuff :( -->
+<script type="text/javascript">
+  $(document).ready(function(){
+     $("#table1_filter").parent().removeClass("col-sm-12 col-md-6");
+     $("#table1_filter").parent().addClass("col-sm-12 col-md-12");
+     $("#table2_filter").parent().removeClass("col-sm-12 col-md-6");
+     $("#table2_filter").parent().addClass("col-sm-12 col-md-12");
+   });
+</script>
+{% endblock scripts %}


### PR DESCRIPTION
The data tables on the report now have pages! Instead of getting a list of 100 items, you now see five at a time.

Also fixed a server issue while I was in there. The DB provider [clearDB], has a non-adjustable server timeout configuration. To mitigate dropping connections, we now ping the server between requests. 

[Here is the StackOverflow post I referenced to solve this problem](https://stackoverflow.com/questions/58659316/pymysql-err-operationalerror-2013-lost-connection-to-mysql-server-during-que)

This is what the configurations look like ->
` from flask_sqlalchemy import SQLAlchemy`  
` from sqlalchemy.pool import QueuePool`  
` db = SQLAlchemy(engine_options =  {"pool_size": 10, "poolclass":QueuePool, "pool_pre_ping":True} )` 

See screenshot to see pagination update
![Screen Shot 2020-03-24 at 11 07 13 PM](https://user-images.githubusercontent.com/30307618/77507632-0a5e8280-6e26-11ea-8cc9-87e268ce9bc9.png)
