### PR TITLE
Viewport Fix

### DIFF
--- a/server.py
+++ b/server.py
@@ -216,6 +216,7 @@ def not_found(e=None):
     return render_template('error.html', e=e)
 # ----------------------
 if __name__ == '__main__':
-    from waitress import serve
-    serve(app)
+    # from waitress import serve
+    # serve(app)
+    app.run(debug=True)
 # ----------------------

--- a/server.py
+++ b/server.py
@@ -216,7 +216,7 @@ def not_found(e=None):
     return render_template('error.html', e=e)
 # ----------------------
 if __name__ == '__main__':
-    # from waitress import serve
-    # serve(app)
-    app.run(debug=True)
+    from waitress import serve
+    serve(app)
+    # app.run(debug=True)
 # ----------------------

--- a/templates/view_decoded.html
+++ b/templates/view_decoded.html
@@ -2,6 +2,14 @@
 {% block content %}
 <!-- Add embedded styling for row -->
 <style>
+  /* 768px and below */
+  /* Adjust the VIN title on this page so that it doesnt overflow */
+  @media screen and (max-width: 768px) {
+    #vin-title {
+      font-size:1.5rem !important;
+    }
+    /* Adjust report column on mobile view */
+  }
   .row {
     /* have to add this because datatables adds margin */
     margin-left:0px !important;
@@ -25,7 +33,7 @@
       <div class="row" style="padding-bottom: 15px;">
         <div class="col">
           <form class="text-center shadow" style="max-width: 100%;">
-            <h2 style="padding-bottom: 15px;">Information gathered from <strong>{{ response['SearchCriteria'][4:] }}</strong></h2>
+            <h2 style="padding-bottom: 15px;">Information gathered from <strong id="vin-title">{{ response['SearchCriteria'][4:] }}</strong></h2>
             <div class="table-responsive">
               <table class="table">
               <!-- Create a list of strings that we want to ignore -->

--- a/templates/view_decoded.html
+++ b/templates/view_decoded.html
@@ -3,12 +3,15 @@
 <!-- Add embedded styling for row -->
 <style>
   /* 768px and below */
-  /* Adjust the VIN title on this page so that it doesnt overflow */
   @media screen and (max-width: 768px) {
+    /* Adjust the VIN title on this page so that it doesnt overflow */
     #vin-title {
-      font-size:1.5rem !important;
+      font-size:1.4rem !important;
     }
-    /* Adjust report column on mobile view */
+    /* Adjust table font size on mobile view */
+    td {
+      font-size:.65rem !important;
+    }
   }
   .row {
     /* have to add this because datatables adds margin */


### PR DESCRIPTION
Fixes an issue on the decoder report interface where the VIN that was entered would overflow pass the bounds of its container. See the linked issue to see an example of the issue.

**Resolved issue by adding a media query for devices with width < 768 pixels.**

The font size for the VIN within the title is adjusted within these constraints. While I was in there, I didn't like how the table had horizontal overflow for mobile devices, considering there are only two columns. So I added an additional style update for mobile devices to reduce the table's font size on mobile devices. The end result is that both columns and title fit well onto the screen, be it any mobile device that is less than 768px in width.

![Screen Shot 2020-05-29 at 1 36 57 PM](https://user-images.githubusercontent.com/30307618/83303218-84f2a800-a1b1-11ea-8d14-eef781dd8fec.png)
